### PR TITLE
Fixed 0 handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "minecraft-varint"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["luojia65 <me@luojia.cc>", "belohnung <belohnung@protonmail.com>"]
 description = "Minecraft's VarInt and VarLong implemetation in Rust, providing minimum memory usage and maximum performance."
 license = "WTFPL"
 readme = "README.md"
-repository = "https://github.com/luojia65/mc-varint"
-documentation = "https://docs.rs/mc-varint"
+repository = "https://github.com/belohnung/minecraft-varint"
+documentation = "https://docs.rs/minecraft-varint"
 keywords = ["minecraft"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "mc-varint"
-version = "0.1.3"
-authors = ["luojia65 <me@luojia.cc>"]
+name = "minecraft-varint"
+version = "0.1.0"
+authors = ["luojia65 <me@luojia.cc>", "belohnung <belohnung@protonmail.com>"]
 description = "Minecraft's VarInt and VarLong implemetation in Rust, providing minimum memory usage and maximum performance."
 license = "WTFPL"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mc-varint
+# minecaft-varint
 Minecraft VarInt and VarLong implemetation in Rust, providing minimum memory usage and maximum performance.
 
 [![Crates.io][crates-badge]][crates-url]
@@ -41,20 +41,3 @@ fn main() {
 }
 ```
 
-# Performance
-
-Platform: 3.4GHz Intel Core i5
-
-```
-running 8 tests
-test read_i32  ... bench:           5 ns/iter (+/- 1)
-test read_i64  ... bench:           4 ns/iter (+/- 1)
-test read_u32  ... bench:           4 ns/iter (+/- 1)
-test read_u64  ... bench:           4 ns/iter (+/- 0)
-test write_i32 ... bench:           4 ns/iter (+/- 0)
-test write_i64 ... bench:           4 ns/iter (+/- 0)
-test write_u32 ... bench:           4 ns/iter (+/- 0)
-test write_u64 ... bench:           4 ns/iter (+/- 0)
-
-test result: ok. 0 passed; 0 failed; 0 ignored; 8 measured; 0 filtered out
-```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Minecraft VarInt and VarLong implemetation in Rust, providing minimum memory usa
 [![Crates.io][crates-badge]][crates-url]
 [![WTFPL licensed][pl-badge]][pl-url]
 
-[crates-badge]: https://img.shields.io/crates/v/mc-varint.svg
-[crates-url]: https://crates.io/crates/mc-varint
+[crates-badge]: https://img.shields.io/crates/v/minecraft-varint.svg
+[crates-url]: https://crates.io/crates/minecraft-varint
 [pl-badge]: https://img.shields.io/badge/license-WTFPL-blue.svg
 [pl-url]: LICENSE
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Minecraft VarInt and VarLong implemetation in Rust, providing minimum memory usa
 
 ## Read a VarInt from a Read
 
-```Rust
+```rust
 use mc_varint::VarIntRead;
 use std::io::Cursor;
 fn main() {
@@ -28,7 +28,7 @@ fn main() {
 
 ## Write a VarInt to a Write
 
-```Rust
+```rust
 use mc_varint::{VarInt, VarIntWrite};
 use std::io::Cursor;
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ fn zigzag_encode_32(src: i32) -> u32 {
 }
 
 fn zigzag_decode_32(src: u32) -> i32 {
-    if src & 1 != 0 { - ((src >> 1) as i32) - 1 } else { (src >> 1) as i32 }
+    if src & 1 != 0 { -((src >> 1) as i32) - 1 } else { (src >> 1) as i32 }
 }
 
 fn zigzag_encode_64(src: i64) -> u64 {
@@ -17,7 +17,7 @@ fn zigzag_encode_64(src: i64) -> u64 {
 }
 
 fn zigzag_decode_64(src: u64) -> i64 {
-    if src & 1 != 0 { - ((src >> 1) as i64) - 1 } else { (src >> 1) as i64 }
+    if src & 1 != 0 { -((src >> 1) as i64) - 1 } else { (src >> 1) as i64 }
 }
 
 pub trait VarIntRead {
@@ -76,22 +76,25 @@ where R: std::io::Read {
         }
         Ok(ans)
     }
-    
 }
 
 #[cfg(not(no_std))]
-impl<W> VarIntWrite for W 
+impl<W> VarIntWrite for W
 where W: std::io::Write {
     fn write_var_i32(&mut self, mut value: i32) -> Result<usize> {
         let mut buf = [0];
         let mut cnt = 0;
-        while value != 0 {
+        loop {
             buf[0] = (value & 0b0111_1111) as u8;
             value = (value >> 7) & (i32::max_value() >> 6);
             if value != 0 {
                 buf[0] |= 0b1000_0000;
             }
             cnt += self.write(&mut buf)?;
+
+            if value == 0 {
+                break;
+            }
         }
         Ok(cnt)
     }
@@ -99,15 +102,18 @@ where W: std::io::Write {
     fn write_var_i64(&mut self, mut value: i64) -> Result<usize> {
         let mut buf = [0];
         let mut cnt = 0;
-        while value != 0 {
+        loop {
             buf[0] = (value & 0b0111_1111) as u8;
             value = (value >> 7) & (i64::max_value() >> 6);
             if value != 0 {
                 buf[0] |= 0b1000_0000;
             }
             cnt += self.write(&mut buf)?;
+
+            if value == 0 {
+                break;
+            }
         }
         Ok(cnt)
     }
-
 }


### PR DESCRIPTION
There was an translation issue between java and rust where do while was interpreted with while which led to ignoring 0 bytes.

[Java](https://wiki.vg/Protocol#VarInt_and_VarLong)